### PR TITLE
add --debug to build system

### DIFF
--- a/Build Systems/Elm Make.sublime-build
+++ b/Build Systems/Elm Make.sublime-build
@@ -14,7 +14,6 @@
     "error_format": "-- $type: $tag - $file:$line:$column\n$message\n",
     "info_format": ":: $info\n",
     "syntax": "Packages/Elm Language Support/Syntaxes/Elm Compile Messages.hidden-tmLanguage",
-    "color_scheme": "Packages/Color Scheme - Default/Sunburst.tmTheme",
     "null_device": "/dev/null",
     "warnings": "true",
     "osx":

--- a/Build Systems/Elm Make.sublime-build
+++ b/Build Systems/Elm Make.sublime-build
@@ -42,6 +42,18 @@
             "warnings": "false"
         },
         {
+            "name": "Run - debug",
+            "cmd":
+            [
+                "elm-make",
+                "$file",
+                "--output={output}",
+                "--report=json",
+                "--debug",
+                "--yes"
+            ]
+        },
+        {
             "name": "Run - Ignore Warnings",
             "warnings": "false",
             "cmd":

--- a/Settings/Elm Language Support.sublime-settings
+++ b/Settings/Elm Language Support.sublime-settings
@@ -5,5 +5,6 @@
     "elm_format_binary": "elm-format",
     "elm_format_on_save": true,
     "elm_format_filename_filter": "",
-    "elm_paths": ""
+    "elm_paths": "",
+    "build_error_color_scheme": "Packages/Color Scheme - Default/Sunburst.tmTheme"
 }

--- a/elm_make.py
+++ b/elm_make.py
@@ -1,6 +1,7 @@
 import json
 import re
 import string
+import sublime
 
 try:     # ST3
     from .elm_plugin import *
@@ -14,13 +15,13 @@ default_exec = import_module('Default.exec')
 class ElmMakeCommand(default_exec.ExecCommand):
 
     # inspired by: http://www.sublimetext.com/forum/viewtopic.php?t=12028
-    def run(self, error_format, info_format, syntax, color_scheme, null_device, warnings, **kwargs):
+    def run(self, error_format, info_format, syntax, null_device, warnings, **kwargs):
         self.buffer = b''
         self.warnings = warnings == "true"
         self.error_format = string.Template(error_format)
         self.info_format = string.Template(info_format)
         self.run_with_project(null_device=null_device, **kwargs)
-        self.style_output(syntax, color_scheme)
+        self.style_output(syntax)
 
     def run_with_project(self, cmd, working_dir, null_device, **kwargs):
         file_arg, output_arg = cmd[1:3]
@@ -37,8 +38,11 @@ class ElmMakeCommand(default_exec.ExecCommand):
         # ST2: TypeError: __init__() got an unexpected keyword argument 'syntax'
         super(ElmMakeCommand, self).run(cmd, working_dir=project_dir, **kwargs)
 
-    def style_output(self, syntax, color_scheme):
+    def style_output(self, syntax):
         self.output_view.set_syntax_file(syntax)
+        elm_setting = sublime.load_settings('Elm Language Support.sublime-settings')
+        user_setting = sublime.load_settings('Preferences.sublime-settings')
+        color_scheme = elm_setting.get('build_error_color_scheme') or user_setting.get('color_scheme')
         self.output_view.settings().set('color_scheme', color_scheme)
         if self.is_patched:
             self.debug_text = ''


### PR DESCRIPTION
I change the color scheme since we should allow users to select. When we are using this theme we get this warning in the console.
```
Running elm-make /Users/simon/Library/Application Support/Sublime Text 3/Packages/Elm Language Support/untitled.elm --output=/dev/null --report=json --yes
"Packages/Color Scheme - Default/Sunburst.tmTheme" is no longer maintained and is now part of "Color Scheme - Legacy"
```

fix #33 