### PR TITLE
Suppress console flash on Windows

### DIFF
--- a/elm_format.py
+++ b/elm_format.py
@@ -12,11 +12,8 @@ USER_SETTING_PREFIX = 'elm_language_support_'
 
 class ElmFormatCommand(sublime_plugin.TextCommand):
     def run(self, edit):
-        # Hide the console window on Windows
-        shell = False
         path_separator = ':'
         if os.name == "nt":
-            shell = True
             path_separator = ';'
 
         binary = self.get_setting('elm_format_binary') or 'elm-format'
@@ -28,7 +25,13 @@ class ElmFormatCommand(sublime_plugin.TextCommand):
 
         working_dir = self.working_dir()
         command = binary.split() + [self.view.file_name(), '--yes'] + options.split()
-        p = subprocess.Popen(command, cwd=working_dir, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=shell)
+        p = subprocess.Popen(
+            command,
+            cwd=working_dir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            startupinfo=get_popen_startupinfo()
+        )
 
         if path:
             os.environ['PATH'] = old_path

--- a/elm_make.py
+++ b/elm_make.py
@@ -50,11 +50,21 @@ class ElmMakeCommand(sublime_plugin.WindowCommand):
             self.proc.terminate()
             self.proc = None
 
+        # Configure Popen to hide console on Windows
+        # https://stackoverflow.com/questions/1765078/how-to-avoid-console-window-with-pyw-file-containing-os-system-call/12964900#12964900
+        # https://docs.python.org/3.3/library/subprocess.html#subprocess.STARTUPINFO
+        startupinfo = None
+        if os.name == 'nt':
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+            startupinfo.wShowWindow = subprocess.SW_HIDE
+
         self.proc = subprocess.Popen(
             self.format_cmd(cmd),
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            cwd=working_dir
+            cwd=working_dir,
+            startupinfo=startupinfo
         )
         self.killed = False
 

--- a/elm_make.py
+++ b/elm_make.py
@@ -50,21 +50,12 @@ class ElmMakeCommand(sublime_plugin.WindowCommand):
             self.proc.terminate()
             self.proc = None
 
-        # Configure Popen to hide console on Windows
-        # https://stackoverflow.com/questions/1765078/how-to-avoid-console-window-with-pyw-file-containing-os-system-call/12964900#12964900
-        # https://docs.python.org/3.3/library/subprocess.html#subprocess.STARTUPINFO
-        startupinfo = None
-        if os.name == 'nt':
-            startupinfo = subprocess.STARTUPINFO()
-            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-            startupinfo.wShowWindow = subprocess.SW_HIDE
-
         self.proc = subprocess.Popen(
             self.format_cmd(cmd),
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             cwd=working_dir,
-            startupinfo=startupinfo
+            startupinfo=get_popen_startupinfo()
         )
         self.killed = False
 

--- a/elm_plugin.py
+++ b/elm_plugin.py
@@ -1,6 +1,8 @@
 import sublime
 import sublime_plugin
+import os
 import os.path as fs
+import subprocess
 
 def is_ST2():
     return sublime.version().startswith('2')
@@ -66,3 +68,19 @@ def replace_base_class(path):
         return target_cls
 
     return decorator
+
+# Construct STARTUPINFO value that can be passed to Popen constructor on
+# Windows to suppress the console window that otherwise gets flashed when
+# elm.exe or elm-format.exe is run; this is more secure than passing
+# 'shell=True'.
+#
+# https://stackoverflow.com/questions/1765078/how-to-avoid-console-window-with-pyw-file-containing-os-system-call/12964900#12964900
+# https://docs.python.org/3.3/library/subprocess.html#subprocess.STARTUPINFO
+def get_popen_startupinfo():
+    if os.name == 'nt':
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+        startupinfo.wShowWindow = subprocess.SW_HIDE
+        return startupinfo
+    else:
+        return None


### PR DESCRIPTION
Finally got around to investigating #50 and found out that there's a (Windows-specific) bit of functionality in Python's `Popen` constructor to suppress the console window. Not entirely sure why this wasn't an issue with the 0.18 version - was `shell=True` used before, perhaps? According to https://docs.python.org/3.3/library/subprocess.html#subprocess.STARTUPINFO, passing `shell=True` will implicitly cause `SW_HIDE` to be set (but using `shell=True` is ["strongly discouraged"](https://docs.python.org/3.3/library/subprocess.html#frequently-used-arguments) for security reasons, so it's better to configure `startupinfo` explicitly).

This change solves the issue for me on Windows (and _seems_ to make running `elm make` a little bit faster, as a bonus). I don't currently have a Mac or Linux machine, so this has not yet been tested to make sure that it doesn't cause problems on other OSes (the `if os.name == 'nt'` _should_ take care of that, but I may have messed something up).